### PR TITLE
Update default.json

### DIFF
--- a/conf/default.json
+++ b/conf/default.json
@@ -7,7 +7,10 @@
 	},
 	"log": {
 		"filePath": "",
-		"options": { "reloadSecs": 60 }
+		"options": {
+			"reloadSecs": 60,
+			"replaceConsole": true
+		}
 	},
 	"queue": {
 		"visibilityTimeout": 300,


### PR DESCRIPTION
Update default.json after document server upgraded to 5.2.4-94
Without this new parameter onlyoffice-documentserver:spellchecker gc docservice converter doesn't start
The metrics still not start: ERROR (spawn error)