### PR TITLE
[fix] Ensure fonts are generated

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -160,6 +160,14 @@ supervisorctl restart all
 sleep 30
 
 #=================================================
+# REGENERATE FONTS
+#=================================================
+ynh_print_info --message="Generating fonts..."
+
+/usr/bin/documentserver-generate-allfonts.sh
+
+
+#=================================================
 # GENERIC FINALIZATION
 #=================================================
 # SETUP SSOWAT

--- a/scripts/restore
+++ b/scripts/restore
@@ -120,6 +120,13 @@ ynh_print_info --message="Restoring the configuration..."
 ynh_restore_file --origin_path="/etc/onlyoffice"
 
 #=================================================
+# REGENERATE FONTS
+#=================================================
+ynh_print_info --message="Generating fonts..."
+
+/usr/bin/documentserver-generate-allfonts.sh
+
+#=================================================
 # GENERIC FINALIZATION
 #=================================================
 # RELOAD NGINX

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -153,6 +153,13 @@ ynh_replace_string --match_string="\"rejectUnauthorized\": true" --replace_strin
 ynh_store_file_checksum --file="/etc/onlyoffice/documentserver/default.json"
 
 #=================================================
+# REGENERATE FONTS
+#=================================================
+ynh_print_info --message="Generating fonts..."
+
+/usr/bin/documentserver-generate-allfonts.sh
+
+#=================================================
 # GENERIC FINALIZATION
 #=================================================
 # SETUP SSOWAT


### PR DESCRIPTION
## Problem
Sometimes fonts are not generated there is error like

```
2020/04/03 17:29:05 [error] 15255#15255: *46197 open() "/var/www/onlyoffice/documentserver/sdkjs/common/AllFonts.js" failed (2: No such file or directory), client: 127.0.0.1, server: , request: "GET /5.5.0-165/sdkjs/common/AllFonts.js HTTP/1.1", host: "xxxx", referrer: "https://xxxxx/5.5.0-165/web-apps/apps/documenteditor/main/index_loader.html?_dc=5.5.0-165&lang=fr&customer=ONLYOFFICE&frameEditorId=iframeEditor&compact=true"
```

And instead the document to be displyed i have an infinite loading animation.

## Solution
Regenerate fonts

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 

When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
