### PR TITLE
Properly set the iframing headers

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -10,5 +10,6 @@ location ^~ __PATH__/ {
   proxy_redirect    off;
   proxy_set_header  Host $host;
   proxy_set_header  X-Real-IP $remote_addr;
-  add_header X-Frame-Options "ALLOW-FROM https://__NEXTCLOUDDOMAIN__" always;
+  more_set_headers "X-Frame-Options: ALLOW-FROM https://__NEXTCLOUDDOMAIN__";
+  add_header Content-Security-Policy "frame-ancestors __NEXTCLOUDDOMAIN__" always;
 }


### PR DESCRIPTION
- Use `more_set_headers` for the `X-Frame-Options: ALLOW-FROM`, because we actually need to replace the `SAMEORIGIN` option which is already set. Note that this directive is obsolete and is used only for old browser support purpose.
- Add an additional `Content-Security-Policy` header with the correct content. This header is the one checked by modern browsers (such as Firefox or Chrome) to allow iframing.