### PR TITLE
Correct upgrade

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,7 +6,7 @@
 
 # dependencies used by the app
 pkg_dependencies="postgresql postgresql-contrib libstdc++6 rabbitmq-server libcurl4-dev"
-extra_dependencies="onlyoffice-documentserver>=6.4.2"
+extra_dependencies="onlyoffice-documentserver=6.4.2"
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,6 +6,7 @@
 
 # dependencies used by the app
 pkg_dependencies="postgresql postgresql-contrib libstdc++6 rabbitmq-server libcurl4-dev"
+extra_dependencies="onlyoffice-documentserver>=6.4.2"
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,7 +6,7 @@
 
 # dependencies used by the app
 pkg_dependencies="postgresql postgresql-contrib libstdc++6 rabbitmq-server libcurl4-dev"
-extra_dependencies="onlyoffice-documentserver=6.4.2"
+extra_dependencies="onlyoffice-documentserver"
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/backup
+++ b/scripts/backup
@@ -52,7 +52,7 @@ ynh_backup --src_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 #=================================================
 
 ynh_backup --src_path="/etc/onlyoffice"
-ynh_backup --src_path="/var/lib/onlyoffice/documentserver/App_Data/cache/files"
+ynh_backup --src_path="/var/lib/onlyoffice/documentserver/App_Data/cache/files" --not_mandatory
 
 #=================================================
 # BACKUP THE POSTGRESQL DATABASE

--- a/scripts/backup
+++ b/scripts/backup
@@ -52,6 +52,7 @@ ynh_backup --src_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 #=================================================
 
 ynh_backup --src_path="/etc/onlyoffice"
+ynh_backup --src_path="/var/lib/onlyoffice/documentserver/App_Data/cache/files"
 
 #=================================================
 # BACKUP THE POSTGRESQL DATABASE

--- a/scripts/install
+++ b/scripts/install
@@ -73,32 +73,11 @@ ynh_script_progression --message="Configuring system user..."
 ynh_system_user_create --username=$app
 
 #=================================================
-# ADD ONLYOFFICE REPOSITORY
-#=================================================
-ynh_script_progression --message="Add OnlyOffice repository..."
-
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
-#ynh_install_extra_repo --repo="deb http://download.onlyoffice.com/repo/debian squeeze main" --append
-
-#=================================================
-# INSTALL ONLYOFFICE
-#=================================================
-ynh_script_progression --message="Install OnlyOffice..."
-
-# The onlyoffice dev had the magnificent idea to add a "nginx restart" during
-# the install/configure of their package, which is awful since that will
-# restart nginx and the whole webadmin and maybe even the yunohost command
-# running the install ...
-#ynh_exec_warn_less ynh_add_app_dependencies --package=$extra_dependencies
-
-#=================================================
 # INSTALL DEPENDENCIES
 #=================================================
 ynh_script_progression --message="Installing dependencies..."
 
 ynh_exec_warn_less ynh_install_app_dependencies $pkg_dependencies
-
-ynh_install_extra_app_dependencies --repo="https://download.onlyoffice.com/repo/debian squeeze main" --package=$extra_dependencies
 
 #=================================================
 # CREATE A POSTGRESQL DATABASE
@@ -110,6 +89,20 @@ db_user=$db_name
 ynh_app_setting_set --app=$app --key=db_name --value=$db_name
 ynh_psql_test_if_first_run
 ynh_psql_setup_db --db_user=$db_name --db_name=$db_name
+
+#=================================================
+# INSTALL ONLYOFFICE
+#=================================================
+ynh_script_progression --message="Install OnlyOffice..."
+
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
+
+# The onlyoffice dev had the magnificent idea to add a "nginx restart" during
+# the install/configure of their package, which is awful since that will
+# restart nginx and the whole webadmin and maybe even the yunohost command
+# running the install ...
+
+ynh_install_extra_app_dependencies --repo="https://download.onlyoffice.com/repo/debian squeeze main" --package=$extra_dependencies
 
 #=================================================
 # NGINX CONFIGURATION

--- a/scripts/install
+++ b/scripts/install
@@ -89,14 +89,14 @@ ynh_script_progression --message="Install OnlyOffice..."
 # the install/configure of their package, which is awful since that will
 # restart nginx and the whole webadmin and maybe even the yunohost command
 # running the install ...
-ynh_exec_warn_less ynh_add_app_dependencies --package=$extra_dependencies
+#ynh_exec_warn_less ynh_add_app_dependencies --package=$extra_dependencies
 
 #=================================================
 # INSTALL DEPENDENCIES
 #=================================================
 ynh_script_progression --message="Installing dependencies..."
 
-ynh_exec_warn_less ynh_install_app_dependencies $pkg_dependencies
+ynh_exec_warn_less ynh_install_app_dependencies "$pkg_dependencies $extra_dependencies"
 
 # ynh_install_extra_app_dependencies --repo="https://updates.signald.org unstable main" --package="$extra_dependencies" --key="https://updates.signald.org/apt-signing-key.asc"
 

--- a/scripts/install
+++ b/scripts/install
@@ -96,9 +96,9 @@ ynh_script_progression --message="Install OnlyOffice..."
 #=================================================
 ynh_script_progression --message="Installing dependencies..."
 
-ynh_exec_warn_less ynh_install_app_dependencies "$pkg_dependencies"
+ynh_exec_warn_less ynh_install_app_dependencies $pkg_dependencies
 
-ynh_install_extra_app_dependencies --repo="https://download.onlyoffice.com/repo/debian squeeze main" --package="$extra_dependencies" 
+ynh_install_extra_app_dependencies --repo="https://download.onlyoffice.com/repo/debian squeeze main" --package=$extra_dependencies
 
 #=================================================
 # CREATE A POSTGRESQL DATABASE

--- a/scripts/install
+++ b/scripts/install
@@ -152,6 +152,17 @@ ynh_script_progression --message="Storing the config file checksum..."
 ynh_store_file_checksum --file="/etc/onlyoffice/documentserver/default.json"
 
 #=================================================
+# GENERIC FINALIZATION
+#=================================================
+# SECURE FILES AND DIRECTORIES
+#=================================================
+
+# Set permissions to app files
+chmod 750 "$final_path"
+chmod -R o-rwx "$final_path"
+chown -R $app:www-data "$final_path"
+
+#=================================================
 # RELOAD ONLYOFFICE
 #=================================================
 ynh_script_progression --message="Reloading OnlyOffice..."

--- a/scripts/install
+++ b/scripts/install
@@ -91,20 +91,6 @@ ynh_psql_test_if_first_run
 ynh_psql_setup_db --db_user=$db_name --db_name=$db_name
 
 #=================================================
-# INSTALL ONLYOFFICE
-#=================================================
-ynh_script_progression --message="Install OnlyOffice..."
-
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
-
-# The onlyoffice dev had the magnificent idea to add a "nginx restart" during
-# the install/configure of their package, which is awful since that will
-# restart nginx and the whole webadmin and maybe even the yunohost command
-# running the install ...
-
-ynh_install_extra_app_dependencies --repo="https://download.onlyoffice.com/repo/debian squeeze main" --package=$extra_dependencies
-
-#=================================================
 # NGINX CONFIGURATION
 #=================================================
 ynh_script_progression --message="Configuring NGINX web server..."
@@ -130,6 +116,20 @@ echo onlyoffice-documentserver onlyoffice/db-host string 127.0.0.1 | debconf-set
 echo onlyoffice-documentserver onlyoffice/db-user string $db_user | debconf-set-selections
 echo onlyoffice-documentserver onlyoffice/db-pwd password $db_pwd | debconf-set-selections
 echo onlyoffice-documentserver onlyoffice/db-name string $db_name | debconf-set-selections
+
+#=================================================
+# INSTALL ONLYOFFICE
+#=================================================
+ynh_script_progression --message="Install OnlyOffice..."
+
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
+
+# The onlyoffice dev had the magnificent idea to add a "nginx restart" during
+# the install/configure of their package, which is awful since that will
+# restart nginx and the whole webadmin and maybe even the yunohost command
+# running the install ...
+
+ynh_install_extra_app_dependencies --repo="https://download.onlyoffice.com/repo/debian squeeze main" --package=$extra_dependencies
 
 #=================================================
 # MODIFY A CONFIG FILE

--- a/scripts/install
+++ b/scripts/install
@@ -78,7 +78,7 @@ ynh_system_user_create --username=$app
 ynh_script_progression --message="Add OnlyOffice repository..."
 
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
-ynh_install_extra_repo --repo="deb http://download.onlyoffice.com/repo/debian squeeze main" --append
+#ynh_install_extra_repo --repo="deb http://download.onlyoffice.com/repo/debian squeeze main" --append
 
 #=================================================
 # INSTALL ONLYOFFICE
@@ -96,9 +96,9 @@ ynh_script_progression --message="Install OnlyOffice..."
 #=================================================
 ynh_script_progression --message="Installing dependencies..."
 
-ynh_exec_warn_less ynh_install_app_dependencies "$pkg_dependencies $extra_dependencies"
+ynh_exec_warn_less ynh_install_app_dependencies "$pkg_dependencies"
 
-# ynh_install_extra_app_dependencies --repo="https://updates.signald.org unstable main" --package="$extra_dependencies" --key="https://updates.signald.org/apt-signing-key.asc"
+ynh_install_extra_app_dependencies --repo="https://download.onlyoffice.com/repo/debian squeeze main" --package="$extra_dependencies" 
 
 #=================================================
 # CREATE A POSTGRESQL DATABASE

--- a/scripts/install
+++ b/scripts/install
@@ -81,11 +81,24 @@ apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
 ynh_install_extra_repo --repo="deb http://download.onlyoffice.com/repo/debian squeeze main" --append
 
 #=================================================
+# INSTALL ONLYOFFICE
+#=================================================
+ynh_script_progression --message="Install OnlyOffice..."
+
+# The onlyoffice dev had the magnificent idea to add a "nginx restart" during
+# the install/configure of their package, which is awful since that will
+# restart nginx and the whole webadmin and maybe even the yunohost command
+# running the install ...
+ynh_exec_warn_less ynh_add_app_dependencies --package=$extra_dependencies
+
+#=================================================
 # INSTALL DEPENDENCIES
 #=================================================
 ynh_script_progression --message="Installing dependencies..."
 
 ynh_exec_warn_less ynh_install_app_dependencies $pkg_dependencies
+
+# ynh_install_extra_app_dependencies --repo="https://updates.signald.org unstable main" --package="$extra_dependencies" --key="https://updates.signald.org/apt-signing-key.asc"
 
 #=================================================
 # CREATE A POSTGRESQL DATABASE
@@ -124,17 +137,6 @@ echo onlyoffice-documentserver onlyoffice/db-host string 127.0.0.1 | debconf-set
 echo onlyoffice-documentserver onlyoffice/db-user string $db_user | debconf-set-selections
 echo onlyoffice-documentserver onlyoffice/db-pwd password $db_pwd | debconf-set-selections
 echo onlyoffice-documentserver onlyoffice/db-name string $db_name | debconf-set-selections
-
-#=================================================
-# INSTALL ONLYOFFICE
-#=================================================
-ynh_script_progression --message="Install OnlyOffice..."
-
-# The onlyoffice dev had the magnificent idea to add a "nginx restart" during
-# the install/configure of their package, which is awful since that will
-# restart nginx and the whole webadmin and maybe even the yunohost command
-# running the install ...
-ynh_exec_warn_less ynh_add_app_dependencies --package="onlyoffice-documentserver"
 
 #=================================================
 # MODIFY A CONFIG FILE
@@ -178,8 +180,6 @@ ynh_script_progression --message="Generating fonts..."
 
 /usr/bin/documentserver-generate-allfonts.sh
 
-#=================================================
-# GENERIC FINALIZATION
 #=================================================
 # SETUP SSOWAT
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -55,7 +55,7 @@ ynh_script_progression --message="Removing dependencies..."
 
 # Remove metapackage and its dependencies
 ynh_remove_app_dependencies
-ynh_remove_extra_repo
+#ynh_remove_extra_repo
 
 dpkg --configure -a
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -59,23 +59,6 @@ ynh_script_progression --message="Recreating the dedicated system user..."
 ynh_system_user_create --username=$app
 
 #=================================================
-# SPECIFIC RESTORATION
-#=================================================
-# ADD ONLYOFFICE REPOSITORY
-#=================================================
-ynh_script_progression --message="Add OnlyOffice repository..."
-
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
-ynh_install_extra_repo --repo="deb http://download.onlyoffice.com/repo/debian squeeze main" --append
-
-#=================================================
-# REINSTALL ONLYOFFICE
-#=================================================
-ynh_script_progression --message="Reinstalling OnlyOffice..."
-
-ynh_exec_warn_less ynh_add_app_dependencies --package=$extra_dependencies
-
-#=================================================
 # REINSTALL DEPENDENCIES
 #=================================================
 ynh_script_progression --message="Reinstalling dependencies..."
@@ -83,6 +66,8 @@ ynh_script_progression --message="Reinstalling dependencies..."
 # Define and install dependencies
 ynh_exec_warn_less ynh_install_app_dependencies $pkg_dependencies
 
+#=================================================
+# SPECIFIC RESTORATION
 #=================================================
 # RESTORE THE POSTGRESQL DATABASE
 #=================================================
@@ -102,6 +87,15 @@ echo onlyoffice-documentserver onlyoffice/db-host string 127.0.0.1 | debconf-set
 echo onlyoffice-documentserver onlyoffice/db-user string $db_user | debconf-set-selections
 echo onlyoffice-documentserver onlyoffice/db-pwd password $db_pwd | debconf-set-selections
 echo onlyoffice-documentserver onlyoffice/db-name string $db_name | debconf-set-selections
+
+#=================================================
+# REINSTALL ONLYOFFICE
+#=================================================
+ynh_script_progression --message="Reinstalling OnlyOffice..."
+
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
+
+ynh_install_extra_app_dependencies --repo="https://download.onlyoffice.com/repo/debian squeeze main" --package=$extra_dependencies 
 
 #=================================================
 # RESTORE THE CONFIGURATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -105,6 +105,11 @@ ynh_script_progression --message="Restoring the configuration..."
 ynh_restore_file --origin_path="/etc/onlyoffice"
 
 #=================================================
+# RESTORE THE CACHE
+#=================================================
+ynh_restore_file --origin_path="/var/lib/onlyoffice/documentserver/App_Data/cache/files"
+
+#=================================================
 # REGENERATE FONTS
 #=================================================
 ynh_script_progression --message="Generating fonts..."

--- a/scripts/restore
+++ b/scripts/restore
@@ -69,6 +69,13 @@ apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
 ynh_install_extra_repo --repo="deb http://download.onlyoffice.com/repo/debian squeeze main" --append
 
 #=================================================
+# REINSTALL ONLYOFFICE
+#=================================================
+ynh_script_progression --message="Reinstalling OnlyOffice..."
+
+ynh_exec_warn_less ynh_add_app_dependencies --package=$extra_dependencies
+
+#=================================================
 # REINSTALL DEPENDENCIES
 #=================================================
 ynh_script_progression --message="Reinstalling dependencies..."
@@ -95,13 +102,6 @@ echo onlyoffice-documentserver onlyoffice/db-host string 127.0.0.1 | debconf-set
 echo onlyoffice-documentserver onlyoffice/db-user string $db_user | debconf-set-selections
 echo onlyoffice-documentserver onlyoffice/db-pwd password $db_pwd | debconf-set-selections
 echo onlyoffice-documentserver onlyoffice/db-name string $db_name | debconf-set-selections
-
-#=================================================
-# REINSTALL ONLYOFFICE
-#=================================================
-ynh_script_progression --message="Reinstalling OnlyOffice..."
-
-ynh_exec_warn_less ynh_add_app_dependencies --package="onlyoffice-documentserver"
 
 #=================================================
 # RESTORE THE CONFIGURATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -118,6 +118,17 @@ ynh_script_progression --message="Generating fonts..."
 /usr/bin/documentserver-generate-allfonts.sh
 
 #=================================================
+# GENERIC FINALIZATION
+#=================================================
+# SECURE FILES AND DIRECTORIES
+#=================================================
+
+# Set permissions to app files
+chmod 750 "$final_path"
+chmod -R o-rwx "$final_path"
+chown -R $app:www-data "$final_path"
+
+#=================================================
 # RELOAD ONLYOFFICE
 #=================================================
 ynh_script_progression --message="Reloading OnlyOffice..."

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -81,6 +81,13 @@ ynh_script_progression --message="Making sure dedicated system user exists..."
 ynh_system_user_create --username=$app
 
 #=================================================
+# UPGRADE DEPENDENCIES
+#=================================================
+ynh_script_progression --message="Upgrading dependencies..."
+
+ynh_exec_warn_less ynh_install_app_dependencies $pkg_dependencies
+
+#=================================================
 # STANDARD UPGRADE STEPS
 #=================================================
 # NGINX CONFIGURATION
@@ -97,31 +104,7 @@ fi
 ynh_add_nginx_config "nextclouddomain"
 
 #=================================================
-# UPGRADE DEPENDENCIES
-#=================================================
-ynh_script_progression --message="Upgrading dependencies..."
-
-ynh_exec_warn_less ynh_install_app_dependencies $pkg_dependencies
-
-#=================================================
 # SPECIFIC UPGRADE
-#=================================================
-# ADD ONLYOFFICE REPOSITORY
-#=================================================
-ynh_script_progression --message="Add OnlyOffice repository..."
-
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
-#ynh_install_extra_repo --repo="deb http://download.onlyoffice.com/repo/debian squeeze main" --append
-
-#=================================================
-# UPGRADE ONLYOFFICE
-#=================================================
-ynh_script_progression --message="Upgrading OnlyOffice..."
-
-# ynh_remove_app_dependencies
-ynh_package_remove $extra_dependencies
-ynh_install_extra_app_dependencies --repo="https://download.onlyoffice.com/repo/debian squeeze main" --package=$extra_dependencies 
-
 #=================================================
 # CONFIGURE ONLYOFFICE
 #=================================================
@@ -133,6 +116,18 @@ echo onlyoffice-documentserver onlyoffice/db-host string 127.0.0.1 | debconf-set
 echo onlyoffice-documentserver onlyoffice/db-user string $db_user | debconf-set-selections
 echo onlyoffice-documentserver onlyoffice/db-pwd password $db_pwd | debconf-set-selections
 echo onlyoffice-documentserver onlyoffice/db-name string $db_name | debconf-set-selections
+
+#=================================================
+# UPGRADE ONLYOFFICE
+#=================================================
+ynh_script_progression --message="Upgrading OnlyOffice..."
+
+ynh_remove_extra_repo # backward compat
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
+
+# ynh_remove_app_dependencies
+ynh_package_remove $extra_dependencies
+ynh_install_extra_app_dependencies --repo="https://download.onlyoffice.com/repo/debian squeeze main" --package=$extra_dependencies 
 
 #=================================================
 # MODIFY A CONFIG FILE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -154,6 +154,15 @@ ynh_script_progression --message="Generating fonts..."
 #=================================================
 # GENERIC FINALIZATION
 #=================================================
+# SECURE FILES AND DIRECTORIES
+#=================================================
+
+# Set permissions to app files
+chmod 750 "$final_path"
+chmod -R o-rwx "$final_path"
+chown -R $app:www-data "$final_path"
+
+#=================================================
 # RELOAD ONLYOFFICE
 #=================================================
 ynh_script_progression --message="Reloading OnlyOffice..."

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -119,8 +119,8 @@ apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
 ynh_script_progression --message="Upgrading OnlyOffice..."
 
 # ynh_remove_app_dependencies
-ynh_package_remove onlyoffice-documentserver
-ynh_install_extra_app_dependencies --repo="https://download.onlyoffice.com/repo/debian squeeze main" --package="$extra_dependencies" 
+ynh_package_remove $extra_dependencies
+ynh_install_extra_app_dependencies --repo="https://download.onlyoffice.com/repo/debian squeeze main" --package=$extra_dependencies 
 
 #=================================================
 # CONFIGURE ONLYOFFICE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -114,6 +114,21 @@ apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
 ynh_install_extra_repo --repo="deb http://download.onlyoffice.com/repo/debian squeeze main" --append
 
 #=================================================
+# UPGRADE ONLYOFFICE
+#=================================================
+ynh_script_progression --message="Upgrading OnlyOffice..."
+
+# ynh_remove_app_dependencies
+ynh_exec_warn_less ynh_add_app_dependencies --package=$extra_dependencies
+
+#=================================================
+# UPGRADE DEPENDENCIES
+#=================================================
+ynh_script_progression --message="Upgrading dependencies..."
+
+ynh_exec_warn_less ynh_install_app_dependencies $pkg_dependencies
+
+#=================================================
 # CONFIGURE ONLYOFFICE
 #=================================================
 ynh_script_progression --message="Configuring OnlyOffice..."
@@ -124,13 +139,6 @@ echo onlyoffice-documentserver onlyoffice/db-host string 127.0.0.1 | debconf-set
 echo onlyoffice-documentserver onlyoffice/db-user string $db_user | debconf-set-selections
 echo onlyoffice-documentserver onlyoffice/db-pwd password $db_pwd | debconf-set-selections
 echo onlyoffice-documentserver onlyoffice/db-name string $db_name | debconf-set-selections
-
-#=================================================
-# UPGRADE ONLYOFFICE
-#=================================================
-ynh_script_progression --message="Upgrading OnlyOffice..."
-
-ynh_exec_warn_less ynh_add_app_dependencies --package="onlyoffice-documentserver"
 
 #=================================================
 # MODIFY A CONFIG FILE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -111,7 +111,7 @@ ynh_exec_warn_less ynh_install_app_dependencies $pkg_dependencies
 ynh_script_progression --message="Add OnlyOffice repository..."
 
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
-ynh_install_extra_repo --repo="deb http://download.onlyoffice.com/repo/debian squeeze main" --append
+#ynh_install_extra_repo --repo="deb http://download.onlyoffice.com/repo/debian squeeze main" --append
 
 #=================================================
 # UPGRADE ONLYOFFICE
@@ -119,14 +119,8 @@ ynh_install_extra_repo --repo="deb http://download.onlyoffice.com/repo/debian sq
 ynh_script_progression --message="Upgrading OnlyOffice..."
 
 # ynh_remove_app_dependencies
-ynh_exec_warn_less ynh_add_app_dependencies --package=$extra_dependencies
-
-#=================================================
-# UPGRADE DEPENDENCIES
-#=================================================
-ynh_script_progression --message="Upgrading dependencies..."
-
-ynh_exec_warn_less ynh_install_app_dependencies $pkg_dependencies
+ynh_package_remove onlyoffice-documentserver
+ynh_install_extra_app_dependencies --repo="https://download.onlyoffice.com/repo/debian squeeze main" --package="$extra_dependencies" 
 
 #=================================================
 # CONFIGURE ONLYOFFICE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -122,11 +122,10 @@ echo onlyoffice-documentserver onlyoffice/db-name string $db_name | debconf-set-
 #=================================================
 ynh_script_progression --message="Upgrading OnlyOffice..."
 
-ynh_remove_extra_repo # backward compat
+ynh_remove_extra_repo --name="$app" # backward compat
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
 
 # ynh_remove_app_dependencies
-ynh_package_remove $extra_dependencies
 ynh_install_extra_app_dependencies --repo="https://download.onlyoffice.com/repo/debian squeeze main" --package=$extra_dependencies 
 
 #=================================================


### PR DESCRIPTION
## Problem

- access rights `/var/www/onlyoffice`
- only office debian package not upgrading

## Solution

- [x] apply securing file from example app
- [x] several fixes/improvements for  `ynh_install_app_dependencies`
- [ ] Use YNH_ARCH helper

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
