### PR TITLE
explain setup with onlyoffice_ynh

### DIFF
--- a/doc/DESCRIPTION.md
+++ b/doc/DESCRIPTION.md
@@ -1,12 +1,12 @@
-OnlyOffice Document Server is an online office suite comprising viewers and editors for texts, spreadsheets and presentations, fully compatible with Office Open XML formats: .docx, .xlsx, .pptx and enabling collaborative editing in real time.
+ONLYOFFICE Document Server is an online office suite comprising viewers and editors for texts, spreadsheets and presentations, fully compatible with Office Open XML formats: .docx, .xlsx, .pptx and enabling collaborative editing in real time.
 
-Online collaborative edition of OnlyOffice documents requires: 
+Online collaborative edition of ONLYOFFICE documents requires: 
 1. a server part, with two installation options:
-   1. OnlyOffice Document Server packaged for YunoHost. 
+   1. ONLYOFFICE Document Server packaged for YunoHost. 
    2. The [Community Document Server for Nextcloud](https://apps.nextcloud.com/apps/documentserver_community) 
 
 2. a client part, such as: 
    1. The [ONLYOFFICE connector for Nextcloud](https://apps.nextcloud.com/apps/onlyoffice) 
    2. The [ONLYOFFICE Desktop Editors](https://www.onlyoffice.com/fr/download-desktop.aspx)
 
-The Nextcloud addicts may follow [this tutorial](https://github.com/YunoHost-Apps/nextcloud_ynh#configure-onlyoffice-integration) to install (1.ii) and (2.i) on one Nextcloud instance. However, performance and architecture are limited.
+A solution made easy by YunoHost is to install (1.i) and (2.i), see [section below](https://github.com/YunoHost-Apps/onlyoffice_ynh/#configuration-of-onlyoffice-server). The Nextcloud addicts may follow [this tutorial](https://github.com/YunoHost-Apps/nextcloud_ynh#configure-onlyoffice-integration) to install (1.ii) and (2.i) on one Nextcloud instance. However, performance and architecture are limited.

--- a/doc/DESCRIPTION_fr.md
+++ b/doc/DESCRIPTION_fr.md
@@ -1,12 +1,12 @@
-OnlyOffice Document Server est une suite bureautique en ligne comprenant des visualiseurs et des éditeurs de textes, feuilles de calcul et présentations, entièrement compatible avec les formats Office Open XML: .docx, .xlsx, .pptx et permettant l'édition collaborative en temps réel.
+ONLYOFFICE Document Server est une suite bureautique en ligne comprenant des visualiseurs et des éditeurs de textes, feuilles de calcul et présentations, entièrement compatible avec les formats Office Open XML: .docx, .xlsx, .pptx et permettant l'édition collaborative en temps réel.
 
-L'édition collaborative en ligne des documents OnlyOffice nécessite :
+L'édition collaborative en ligne des documents ONLYOFFICE nécessite :
 1. une partie serveur, avec deux options d'installation :
-    1. OnlyOffice Document Server packagé pour YunoHost.
+    1. ONLYOFFICE Document Server packagé pour YunoHost.
     2. Le [Community Document Server pour Nextcloud](https://apps.nextcloud.com/apps/documentserver_community).
 
 2. une partie client, telle que :
     1. [ONLYOFFICE connector pour Nextcloud](https://apps.nextcloud.com/apps/onlyoffice)
     2. [ONLYOFFICE Desktop Editors](https://www.onlyoffice.com/fr/download-desktop.aspx)
 
-Les utilisateurs de Nextcloud peuvent suivre [ce tutoriel](https://github.com/YunoHost-Apps/nextcloud_ynh/blob/testing/README_fr.md#configurer-lint%C3%A9gration-donlyoffice) pour installer le Community Document Server (1.ii) et ONLYOFFICE connector (2.i) sur une instance Nextcloud. Cependant, les performances et l'architecture sont limitées.
+Une solution rendue facile par YunoHost est d'installer (1.i) et (2.i), voir [ci-dessous](https://github.com/YunoHost-Apps/onlyoffice_ynh/blob/master/README_fr.md#configuration-de-onlyoffice-server). Les utilisateurs qui aiment le tout Nextcloud peuvent suivre [ce tutoriel](https://github.com/YunoHost-Apps/nextcloud_ynh/blob/master/README_fr.md#configurer-lint%C3%A9gration-donlyoffice) pour installer le Community Document Server (1.ii) et ONLYOFFICE connector (2.i) sur une instance Nextcloud. Cependant, les performances et l'architecture sont limitées.

--- a/doc/DISCLAIMER.md
+++ b/doc/DISCLAIMER.md
@@ -1,6 +1,6 @@
 ## Demo
 
-* A free 30 days demo of Document Server is available from OnlyOffice connector for Nextcloud:
+* A free 30 days demo of Document Server is available from ONLYOFFICE connector for Nextcloud:
   * Install Nextcloud and the ONLYOFFICE app (connector).
   * Go in the Nextcloud administrator settings, section ONLYOFFICE.
   * Tick the box `Connection to demo ONLYOFFICE Document Server` in Server Parameters.
@@ -8,30 +8,30 @@
 
 ## Prerequisite
 
-You should not install OnlyOffice on your main YunoHost domain, especially if you want to use it with a Nextcloud installed on the same domain.
-* Add a new domain for OnlyOffice in YunoHost.
+You should not install ONLYOFFICE on your main YunoHost domain, especially if you want to use it with a Nextcloud installed on the same domain.
+* Add a new domain for ONLYOFFICE in YunoHost.
   * If your main YunoHost domain was provided by YunoHost, e.g. `domain.nohost.me`, then you don't have to buy/register a new domain name.
   * Just click on `I already have a domain`.
   * Type e.g. `office.domain.nohost.me` and click on `Add`.
 * Add a Let's Encrypt certificate for this domain.
 
-## Configuration of OnlyOffice Server
+## Configuration of ONLYOFFICE Server
 
 * Assuming that:
   * `yunohost.domain` is your main YunoHost domain.
-  * You have configured `office.yunohost.domain` for OnlyOffice, see Prerequisite above.
+  * You have configured `office.yunohost.domain` for ONLYOFFICE, see Prerequisite above.
   * You have Nextcloud installed on `yunohost.domain/nextcloud` or `nextcloud.yunohost.domain`.
-* Install `onlyoffice` using CLI or webadmin.
-  * Choose a domain name for OnlyOffice that is different from your Nextcloud domain, e.g. `office.yunohost.domain` (or `office.domain.nohost.me`, see previous section).
-  * Choose a path for OnlyOffice, e.g. `/` if you install on `office.yunohost.domain` (do not install any other app on this domain).
+* Install `ONLYOFFICE` using CLI or webadmin.
+  * Choose a domain name for ONLYOFFICE that is different from your Nextcloud domain, e.g. `office.yunohost.domain` (or `office.domain.nohost.me`, see previous section).
+  * Choose a path for ONLYOFFICE, e.g. `/` if you install on `office.yunohost.domain` (do not install any other app on this domain).
   * The domain of your Nextcloud instance, e.g. `yunohost.domain/nextcloud` or `nextcloud.yunohost.domain`.
-  * Is it a public application? **If you want to connect it to Nextcloud, OnlyOffice should be public**: then select `Yes` or `tick the box`.
+  * Is it a public application? **If you want to connect it to Nextcloud, ONLYOFFICE should be public**: then select `Yes` or `tick the box`.
 
-## How to edit OnlyOffice documents?
+## How to edit ONLYOFFICE documents?
 
 ### Web Edition in Nextcloud
 
-Prerequisite: **OnlyOffice should be public**, see previous section.
+Prerequisite: **ONLYOFFICE should be public**, see previous section.
 * In Nextcloud apps store, install `ONLYOFFICE`, i.e. the [ONLYOFFICE connector for Nextcloud](https://apps.nextcloud.com/apps/onlyoffice).
 * Go in the Nextcloud `settings` > `Administration` > `ONLYOFFICE` > `Server settings` > `Address of the Document Server`.
 * Give the installation domain of your `onlyoffice`, e.g. `https://office.yunohost.domain/` and click `Save`.
@@ -41,7 +41,7 @@ Prerequisite: **OnlyOffice should be public**, see previous section.
 
 * Download and install a [ONLYOFFICE Desktop Editors](https://www.onlyoffice.com/fr/download-desktop.aspx).
 * Start ONLYOFFICE and Go to `Connect to cloud` > `Add cloud`.
-  * Select `ONLYOFFICE` and give the installation domain of your `onlyoffice`, e.g. `office.yunohost.domain`
-  * or (only if you connected `onlyoffice` to Nextcloud, see previous section).
+  * Select `ONLYOFFICE` and give the installation domain of your `ONLYOFFICE`, e.g. `office.yunohost.domain`
+  * or (only if you connected `ONLYOFFICE` to Nextcloud, see previous section).
   * Select `Nextcloud` and give your Nextcloud installation domain, e.g. `yunohost.domain/nextcloud`.
 * Create a new document and enjoy!

--- a/doc/DISCLAIMER_fr.md
+++ b/doc/DISCLAIMER_fr.md
@@ -1,6 +1,6 @@
 ## Démo
 
-* Une démo gratuite de 30 jours de Document Server est disponible à partir du connecteur OnlyOffice pour Nextcloud:
+* Une démo gratuite de 30 jours de Document Server est disponible à partir du connecteur ONLYOFFICE pour Nextcloud:
    * Installez Nextcloud et l'application ONLYOFFICE (connector).
    * Allez dans les paramètres de l'administrateur Nextcloud, section ONLYOFFICE.
    * Cochez la case `Connexion à la démonstration ONLYOFFICE Document Server` dans les paramètres du serveur.
@@ -8,40 +8,40 @@
 
 ## Prérequis
 
-Vous ne devez pas installer OnlyOffice sur votre domaine YunoHost principal, surtout si vous souhaitez l'utiliser avec une instance Nextcloud installée sur le même domaine.
-* Ajouter un nouveau domaine pour OnlyOffice dans YunoHost
+Vous ne devez pas installer ONLYOFFICE sur votre domaine YunoHost principal, surtout si vous souhaitez l'utiliser avec une instance Nextcloud installée sur le même domaine.
+* Ajouter un nouveau domaine pour ONLYOFFICE dans YunoHost
    * Si votre domaine YunoHost principal a été fourni par YunoHost, par exemple `domain.nohost.me`, alors vous n'avez pas à acheter/enregistrer un nouveau nom de domaine.
    * Cliquez simplement sur `J'ai déjà un nom de domaine`.
    * Tapez par exemple `office.domain.nohost.me` et cliquez sur `Ajouter`.
 * Ajoutez un certificat Let's Encrypt pour ce domaine.
 
-## Configuration de OnlyOffice Server
+## Configuration de ONLYOFFICE Server
 
 * Supposons que :
    * `yunohost.domain` est votre domaine principal YunoHost.
-   * Vous avez configuré `office.yunohost.domain` pour OnlyOffice, voir Prérequis ci-dessus
+   * Vous avez configuré `office.yunohost.domain` pour ONLYOFFICE, voir Prérequis ci-dessus
    * Vous avez Nextcloud installé sur `yunohost.domain / nextcloud` ou `nextcloud.yunohost.domain`.
-* Installez `onlyoffice` à l'aide de la CLI ou de l'administrateur Web
-   * choisissez un nom de domaine pour OnlyOffice différent de votre domaine Nextcloud, par exemple `office.yunohost.domain`  (ou `office.domain.nohost.me`, voir section précédente).
-   * Choisissez un chemin pour OnlyOffice, par exemple `/` si vous installez sur `office.yunohost.domain` (n'installez aucune autre application sur ce domaine).
+* Installez `ONLYOFFICE` à l'aide de la CLI ou de l'administrateur Web
+   * choisissez un nom de domaine pour ONLYOFFICE différent de votre domaine Nextcloud, par exemple `office.yunohost.domain`  (ou `office.domain.nohost.me`, voir section précédente).
+   * Choisissez un chemin pour ONLYOFFICE, par exemple `/` si vous installez sur `office.yunohost.domain` (n'installez aucune autre application sur ce domaine).
    * Le domaine de votre instance Nextcloud, par exemple `yunohost.domain / nextcloud` ou `nextcloud.yunohost.domain`.
-   * Est-ce une application publique ? **Si vous souhaitez le connecter à Nextcloud, OnlyOffice doit être public** : puis sélectionnez `Oui` ou `cochez la case`.
+   * Est-ce une application publique ? **Si vous souhaitez le connecter à Nextcloud, ONLYOFFICE doit être public** : puis sélectionnez `Oui` ou `cochez la case`.
 
-## Comment éditer des documents OnlyOffice ?
+## Comment éditer des documents ONLYOFFICE ?
 
 ### Web Édition dans Nextcloud
 
-Prérequis : **OnlyOffice doit être public**, voir la section précédente.
-* dans le magasin d'applications Nextcloud, installez `ONLYOFFICE`, c'est-à-dire le [connecteur OnlyOffice pour Nextcloud](https://apps.nextcloud.com/apps/onlyoffice)
+Prérequis : **ONLYOFFICE doit être public**, voir la section précédente.
+* dans le magasin d'applications Nextcloud, installez `ONLYOFFICE`, c'est-à-dire le [connecteur ONLYOFFICE pour Nextcloud](https://apps.nextcloud.com/apps/onlyoffice)
 * Allez dans Nextcloud `Paramètres` > `Administration` > `ONLYOFFICE` > `Paramètres du serveur` > `Adresse du service d'édition de document`.
-* Spécifiez le domaine d'installation de votre serveur `onlyoffice`, par exemple `https://office.yunohost.domain/` et cliquez sur `Enregistrer`.
+* Spécifiez le domaine d'installation de votre serveur `ONLYOFFICE`, par exemple `https://office.yunohost.domain/` et cliquez sur `Enregistrer`.
 * Créez un nouveau document !
 
 ### Desktop Édition sur PC
 
 * Téléchargez et installez [ONLYOFFICE Desktop Editors](https://www.onlyoffice.com/fr/download-desktop.aspx)
 * Démarrez l'éditeur et allez dans `Connecter au Cloud` > `Ajouter cloud`
-  * sélectionnez ONLYOFFICE et indiquez le domaine d'installation de votre server OnlyOffice, par ex. `office.yunohost.domain`
-  * ou (uniquement si vous avez connecté `onlyoffice` à Nextcloud, voir section précédente).
+  * sélectionnez ONLYOFFICE et indiquez le domaine d'installation de votre server ONLYOFFICE, par ex. `office.yunohost.domain`
+  * ou (uniquement si vous avez connecté `ONLYOFFICE` à Nextcloud, voir section précédente).
   * Sélectionnez `Nextcloud` et donnez votre domaine d'installation Nextcloud, par exemple `yunohost.domain/nextcloud`.
 * Créez un nouveau document !


### PR DESCRIPTION
- explain setup with with onlyoffice_ynh made easy by YunoHost (instead of nextcloud document server app)
- standardize writing of `ONLYOFFICE` (instead of OnlyOffice or onlyoffice)